### PR TITLE
Updated .gitignore to correctly ignore .txt file found in any /labels/ directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.DS_Store
 
 # Exclude text files found in 'labels' directories
-labels/*.txt
+**/labels/*.txt
 
 # Exclude runs directory from any Modeling subfolders
 /Vision/Modeling/**/runs/


### PR DESCRIPTION
Previously, these files were not being ignored.  They don't serve any purpose to track, and likely just eat up a bunch of space.