### PR TITLE
Split stream module out of feed 

### DIFF
--- a/Scripts/Modules/Data/project_data.py
+++ b/Scripts/Modules/Data/project_data.py
@@ -69,12 +69,12 @@ class ProjectData(ABC):
             if self.logging:
                 print(f"Analyzing frame")
             model = YOLO(self.model_path) # Load the model.
-            results = model(frame) # Analyze the frame with the model.
+            results = model(frame)[0] # Analyze the frame with the model.
             self.results.append(results) # Store the results.
             if self.logging:
                 print(f"Frame analysis complete")
             # TODO: Add code here to create an annotated frame based on the results, and send that back to the main process instead of the original frame.
-            annotated_frame = frame # This is a simple way to create an annotated frame, but it may not be the best way depending on how you want to display the results.  You may want to create a custom function to draw the annotations in a specific way.
+            annotated_frame = results.plot() # This is the easiest way to show the annotated frame, but I'm not sure if it's how I want to do it in the future.
             self.main_queue.put(QueueData(cmd=QuCmd.FRAME_READY, data=annotated_frame)) # Send the annotated frame back to the main process.
             return
         self.main_queue.put(QueueData(cmd=QuCmd.FRAME_READY, data=frame)) # If no model, just send the original frame back to the main process.

--- a/Scripts/Modules/Feed/feed.py
+++ b/Scripts/Modules/Feed/feed.py
@@ -24,32 +24,3 @@ class Feed(ABC):
     def _capture_frame(self) -> None:
         """Capture a single frame from the feed."""
         pass
-
-    def _open_window(self):
-        """Open a window to display the feed."""
-        window_name = 'Die Tester - Camera Feed'
-        cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
-        cv2.waitKey(1)  # Brief pause to ensure window displays
-        return window_name
-    
-    def _close_window(self):
-        """Close the feed window."""
-        if hasattr(self, 'window') and self.window:
-            cv2.destroyWindow(self.window)
-            cv2.waitKey(1)  # Brief pause to ensure window closes
-            self.window = None
-
-    def show_frame(self, frame: MatLike, delay: int = 1):
-        """Display the frame in the feed window."""
-        if self.window is None:
-            self.window = self._open_window()
-        
-        if frame is None:
-            raise ValueError("No frame to display.")
-        
-        cv2.imshow(self.window, frame)
-        cv2.waitKey(delay)  # Brief pause to ensure window displays
-
-    def destroy(self):
-        """Clean up resources"""
-        self._close_window()

--- a/Scripts/Modules/Stream/stream.py
+++ b/Scripts/Modules/Stream/stream.py
@@ -1,0 +1,43 @@
+# Image support imports
+import cv2
+
+# Class support imports
+from cv2.typing import MatLike
+
+class Stream():
+
+    def __init__(
+            self,
+            logging: bool = False
+        ) -> None:
+        self.logging = logging
+        # I'm not calling _open_window here because I want to delay opening the window until we have a frame to display.  This will prevent an empty window from appearing if whatever process I'm running doesn't need the window.
+
+    def _open_window(self):
+        """Open a window to display the feed."""
+        window_name = 'Die Tester - Camera Feed'
+        cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
+        cv2.waitKey(1)  # Brief pause to ensure window displays
+        return window_name
+    
+    def _close_window(self):
+        """Close the feed window."""
+        if hasattr(self, 'window') and self.window:
+            cv2.destroyWindow(self.window)
+            cv2.waitKey(1)  # Brief pause to ensure window closes
+            self.window = None
+
+    def show_frame(self, frame: MatLike, delay: int = 1):
+        """Display the frame in the feed window."""
+        if self.window is None:
+            self.window = self._open_window()
+        
+        if frame is None:
+            raise ValueError("No frame to display.")
+        
+        cv2.imshow(self.window, frame)
+        cv2.waitKey(delay)  # Brief pause to ensure window displays
+
+    def destroy(self):
+        """Clean up resources"""
+        self._close_window()

--- a/Scripts/Modules/queue_data.py
+++ b/Scripts/Modules/queue_data.py
@@ -5,7 +5,7 @@ class Command(Enum):
     EXIT = auto()
     MAIN_MENU = auto()
     MOVE_TO_UNCAP = auto()
-    FRAME_READY = auto()
+    FRAME_READY = auto() # Notify main process the next frame to show is ready.
 
 class QueueData:
     """

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -6,7 +6,9 @@ import time
 
 # Project module imports
 from Scripts.Modules.queue_data import QueueData, Command as QuCmd
+from Scripts.Modules.Stream.stream import Stream
 from Scripts.Modules.Motor.ad2 import Motor
+from Scripts.Modules.Feed.feed_factory import FeedFactory
 
 # Constants
 ENABLE_LOGGING = True
@@ -40,6 +42,7 @@ def main() -> None:
 
     # Setup
     main_queue = mp.Queue()
+    stream = Stream(logging=ENABLE_LOGGING)
 
     # The first thing we should send to the queue is command to enter the user selection state.
     main_queue.put(QueueData(cmd=QuCmd.MAIN_MENU, data=None))
@@ -56,6 +59,10 @@ def main() -> None:
                     if ENABLE_LOGGING:
                         print("Move to uncap position command received.")
                     move_to_uncap(main_queue)
+                case QuCmd.FRAME_READY:
+                    if ENABLE_LOGGING:
+                        print("Frame ready command received. Displaying frame...")
+                    stream.show_frame(item.data)
                 case QuCmd.EXIT: # Exit the application.
                     if ENABLE_LOGGING:
                         print("Exit command received. Breaking the loop.")
@@ -70,6 +77,7 @@ def main() -> None:
 
     # Breakdown
     close_queue(main_queue)
+    stream.destroy()
 
 """
 These are the main functions for the application.  The main function is responsible for managing the overall flow of the application, while the top_level function is responsible for presenting the user with options and handling their selections.
@@ -113,7 +121,6 @@ def move_to_uncap(queue: mp.Queue) -> None:
     """
     if ENABLE_LOGGING:
         print("Moving to uncap position...)")
-    # Placeholder for actual movement logic
     try:
         motor = Motor(logging=ENABLE_LOGGING, main_queue=queue)
     except Exception as e:


### PR DESCRIPTION
This separates the responsibilities for capturing frames and displaying frames.

This lets me use the main process to manage displaying frames, while letting subprocesses determine what frames are displayed.