### PR TITLE
Add interactive 3D optical path visualisation and hardware docs

### DIFF
--- a/Hardware/lens_wd_calc.py
+++ b/Hardware/lens_wd_calc.py
@@ -1,0 +1,169 @@
+"""
+Lens working-distance & mirror–tower clearance calculator
+for the Die Tester capture chamber.
+
+Lens:   60°(D) × 50°(H) × 38°(V)
+Target: 3.5" (88.9 mm) diameter die landing circle
+
+Geometry: folded optical path via 45° first-surface mirror.
+  Total optical path = horizontal leg (camera → mirror)
+                     + vertical leg   (mirror  → die)
+
+Two independent constraints drive the minimum path:
+
+  1. FOV constraint (optical):
+       WD_min = (D/2) / tan(FOV_V/2)
+       The vertical FOV (38°) is the limiting dimension.
+
+  2. Collision constraint (physical):
+       The dice-tower cylinder must not collide with the top edge of the mirror.
+       min_vert_leg = mirror_top_dist / sqrt(2)
+       where mirror_top_dist is the Euclidean distance from origin to the
+       topmost point of the mirror.
+
+The minimum total WD is driven by the FOV constraint (129.09 mm).
+The split between legs is driven by the collision constraint:
+  vert_leg_min = mirror_top_dist / sqrt(2)   (collision floor)
+  horiz_leg    = WD_total - vert_leg
+"""
+
+import math
+
+
+# ── Lens & target parameters ────────────────────────────────────────────────
+
+FOV_H_DEG = 50.0        # horizontal field of view (°)
+
+FOV_V_DEG = 38.0        # vertical field of view   (°)
+FOV_D_DEG = 60.0        # diagonal field of view   (°)
+
+TARGET_DIA_IN = 3.5                     # die landing zone diameter (inches)
+TARGET_DIA_MM = TARGET_DIA_IN * 25.4   # → 88.9 mm
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def wd_for_fill(obj_size, fov_deg, fill=1.0):
+    """Return WD so that obj_size fills `fill` fraction of the frame
+    dimension corresponding to fov_deg."""
+    return obj_size / (2 * math.tan(math.radians(fov_deg / 2)) * fill)
+
+
+def frame_dims(wd, fov_h=FOV_H_DEG, fov_v=FOV_V_DEG):
+    """Return (frame_width, frame_height) at a given working distance."""
+    w = 2 * wd * math.tan(math.radians(fov_h / 2))
+    h = 2 * wd * math.tan(math.radians(fov_v / 2))
+    return w, h
+
+
+# ── Minimum working distance ─────────────────────────────────────────────────
+
+WD_MIN_IN = wd_for_fill(TARGET_DIA_IN, FOV_V_DEG, fill=1.0)
+WD_MIN_MM = WD_MIN_IN * 25.4
+
+fw0, fh0 = frame_dims(WD_MIN_IN)
+
+print("=" * 64)
+print("  Die Tester · Lens Working-Distance Calculator")
+print("=" * 64)
+print(f"  Lens FOV : {FOV_H_DEG}° (H) × {FOV_V_DEG}° (V)  [{FOV_D_DEG}° diag]")
+print(f"  Target   : ⌀ {TARGET_DIA_IN}\" ({TARGET_DIA_MM:.1f} mm) circle")
+print()
+print("  MINIMUM WORKING DISTANCE  (circle exactly fills V dimension)")
+print(f"    WD_min  = {WD_MIN_IN:.4f}\"  =  {WD_MIN_MM:.2f} mm")
+print(f"    Frame   = {fw0:.4f}\" W × {fh0:.4f}\" H")
+print(f"    Fill    = {TARGET_DIA_IN/fw0*100:.1f}% W,  100.0% V")
+print()
+
+
+# ── Fill-ratio table ──────────────────────────────────────────────────────────
+# No hard optical maximum — the maximum is a design choice.
+# This table shows how WD grows as you allow the circle to fill a smaller
+# fraction of the vertical frame dimension.
+
+print("  FILL-RATIO TABLE  (V fill % → required WD)")
+print(f"  {'V fill':>7}  {'WD (in)':>9}  {'WD (mm)':>9}  "
+      f"{'Frame W (in)':>13}  {'Frame H (in)':>13}  {'H fill':>7}")
+print("  " + "-" * 64)
+for fill_v in [1.00, 0.90, 0.80, 0.75, 0.70, 0.60, 0.50]:
+    wd = wd_for_fill(TARGET_DIA_IN, FOV_V_DEG, fill_v)
+    fw, fh = frame_dims(wd)
+    print(f"  {fill_v*100:>6.0f}%  {wd:>9.4f}  {wd*25.4:>9.2f}  "
+          f"{fw:>13.4f}  {fh:>13.4f}  {TARGET_DIA_IN/fw*100:>6.1f}%")
+print()
+
+
+# ── Folded-path splits ────────────────────────────────────────────────────────
+# For a 45° mirror:  horiz_leg + vert_leg = WD_total
+# Either leg can be the longer one; pick based on enclosure geometry.
+
+# ── Section 2: Mirror–tower collision geometry ───────────────────────────────
+
+MIRROR_TOP_DIST_MM = 40.659   # Euclidean distance from origin to topmost mirror point
+MIRROR_ANGLE_DEG   = 45.0
+
+TOWER_DIA_IN  = 5.0
+TOWER_DIA_MM  = TOWER_DIA_IN * 25.4
+TOWER_RAD_MM  = TOWER_DIA_MM / 2
+TOWER_H_IN    = 6.0
+TOWER_H_MM    = TOWER_H_IN * 25.4
+
+# Topmost mirror point coordinates (at 45°, symmetric)
+mirror_top_x = MIRROR_TOP_DIST_MM * math.cos(math.radians(MIRROR_ANGLE_DEG))
+mirror_top_y = MIRROR_TOP_DIST_MM * math.sin(math.radians(MIRROR_ANGLE_DEG))
+
+# Mirror top is within cylinder footprint when mirror_top_x < tower_radius.
+# In that case, the Y coordinate of the topmost mirror point is the hard floor
+# for the tower bottom (vert leg).
+inside_footprint = mirror_top_x < TOWER_RAD_MM
+z_critical_mm = math.sqrt(TOWER_RAD_MM**2 - mirror_top_x**2) if inside_footprint else 0.0
+
+VERT_LEG_MIN_MM = mirror_top_y          # collision floor
+HORIZ_LEG_AT_MIN_MM = WD_MIN_MM - VERT_LEG_MIN_MM
+
+print("─" * 64)
+print("  MIRROR–TOWER CLEARANCE")
+print("─" * 64)
+print(f"  Mirror half-extent along surface  = {MIRROR_TOP_DIST_MM} mm")
+print(f"  Topmost mirror point  X = {mirror_top_x:.4f} mm,  Y = {mirror_top_y:.4f} mm")
+print()
+print(f"  Tower cylinder  ⌀ {TOWER_DIA_IN}\" ({TOWER_DIA_MM:.1f} mm),  "
+      f"h {TOWER_H_IN}\" ({TOWER_H_MM:.1f} mm)")
+print()
+print(f"  Mirror top X ({mirror_top_x:.2f} mm) < tower radius ({TOWER_RAD_MM:.1f} mm)?  "
+      f"{'YES — inside footprint' if inside_footprint else 'NO — always clear'}")
+if inside_footprint:
+    print(f"  Mirror top edge is inside footprint for |z| < {z_critical_mm:.2f} mm")
+print()
+print(f"  MINIMUM VERTICAL LEG  (mirror centre → tower bottom)")
+print(f"    vert_leg_min  =  {VERT_LEG_MIN_MM:.4f} mm  =  {VERT_LEG_MIN_MM/25.4:.4f} in")
+print(f"    = mirror_top_dist / sqrt(2)  =  {MIRROR_TOP_DIST_MM} / {math.sqrt(2):.6f}")
+print()
+print(f"  MINIMUM-TOTAL-WD FOLDED-PATH BREAKDOWN")
+print(f"    WD_total (optical floor)  =  {WD_MIN_MM:.4f} mm")
+print(f"    Vert leg  (collision floor) =  {VERT_LEG_MIN_MM:.4f} mm  ({VERT_LEG_MIN_MM/25.4:.4f} in)")
+print(f"    Horiz leg                  =  {HORIZ_LEG_AT_MIN_MM:.4f} mm  ({HORIZ_LEG_AT_MIN_MM/25.4:.4f} in)")
+print()
+
+
+# ── Fusion 360 user parameters ────────────────────────────────────────────────
+
+print("─" * 64)
+print("  FUSION 360 USER PARAMETERS  (copy-paste into Parameters dialog)")
+print("─" * 64)
+print(f"  lens_fov_h_deg          = {FOV_H_DEG}")
+print(f"  lens_fov_v_deg          = {FOV_V_DEG}")
+print(f"  target_dia_mm           = {TARGET_DIA_MM:.2f}")
+print(f"  mirror_top_dist_mm      = {MIRROR_TOP_DIST_MM}   ← half-extent of mirror surface")
+print(f"  tower_dia_mm            = {TOWER_DIA_MM}")
+print(f"  tower_height_mm         = {TOWER_H_MM:.1f}")
+print()
+print("  Derived (enter as expressions):")
+print(f"  vert_leg_min_mm         = mirror_top_dist_mm / sqrt(2)          "
+      f"→ {VERT_LEG_MIN_MM:.4f} mm")
+print(f"  wd_min_mm               = (target_dia_mm/2) / tan(lens_fov_v_deg/2 deg)  "
+      f"→ {WD_MIN_MM:.4f} mm")
+print(f"  horiz_leg_min_mm        = wd_min_mm - vert_leg_min_mm           "
+      f"→ {HORIZ_LEG_AT_MIN_MM:.4f} mm")
+print(f"  frame_w_mm              = 2 * wd_min_mm * tan(lens_fov_h_deg/2 deg)")
+print(f"  frame_h_mm              = 2 * wd_min_mm * tan(lens_fov_v_deg/2 deg)")

--- a/Hardware/optical-path-diagram.svg
+++ b/Hardware/optical-path-diagram.svg
@@ -1,0 +1,168 @@
+<svg width="720" height="560" xmlns="http://www.w3.org/2000/svg" font-family="Arial, Helvetica, sans-serif">
+
+  <defs>
+    <marker id="arr-orange" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#e85000"/>
+    </marker>
+    <marker id="arr-grey" markerWidth="7" markerHeight="6" refX="6" refY="3" orient="auto">
+      <polygon points="0,0 7,3 0,6" fill="#888"/>
+    </marker>
+    <marker id="arr-yellow" markerWidth="7" markerHeight="6" refX="6" refY="3" orient="auto">
+      <polygon points="0,0 7,3 0,6" fill="#997700"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="560" fill="#f4f6f9"/>
+
+  <!-- ── Title ────────────────────────────────────────────────── -->
+  <text x="360" y="20" text-anchor="middle" font-size="15" font-weight="bold" fill="#1a2a3a">
+    Die Tester · Folded Optical Path (Side Elevation)
+  </text>
+  <text x="360" y="36" text-anchor="middle" font-size="10" fill="#555">
+    WD_total min = 129.1 mm  ·  vert leg min = 28.8 mm  ·  horiz leg min = 100.3 mm
+  </text>
+
+  <!-- ── Dice Tower ─────────────────────────────────────────── -->
+  <!-- Left wall -->
+  <rect x="327" y="42" width="12" height="138" fill="#90a0b0" stroke="#5a7080" stroke-width="1.5"/>
+  <!-- Right wall -->
+  <rect x="379" y="42" width="12" height="138" fill="#90a0b0" stroke="#5a7080" stroke-width="1.5"/>
+  <!-- Open top cap lines -->
+  <line x1="327" y1="42" x2="339" y2="42" stroke="#5a7080" stroke-width="2"/>
+  <line x1="379" y1="42" x2="391" y2="42" stroke="#5a7080" stroke-width="2"/>
+  <!-- Falling die indicator (arrow in channel) -->
+  <line x1="359" y1="60" x2="359" y2="148" stroke="#666" stroke-width="2"/>
+  <polygon points="359,155 351,142 367,142" fill="#666"/>
+  <!-- Tower label -->
+  <text x="412" y="90" font-size="11" fill="#4a6070">Dice tower</text>
+  <line x1="408" y1="88" x2="393" y2="88" stroke="#7a9aaa" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr-grey)"/>
+
+  <!-- ── Capture Chamber ────────────────────────────────────── -->
+  <rect x="197" y="180" width="308" height="258" fill="#e8eef7" stroke="#4a6a9a" stroke-width="2"/>
+  <text x="490" y="199" text-anchor="end" font-size="9.5" fill="#7a9aaa" font-style="italic">capture chamber</text>
+
+  <!-- ── Acrylic Cap ──────────────────────────────────────── -->
+  <line x1="217" y1="288" x2="483" y2="288" stroke="#4488dd" stroke-width="5" stroke-linecap="round" opacity="0.82"/>
+  <text x="520" y="293" font-size="11" fill="#1a55bb">Acrylic cap</text>
+  <line x1="517" y1="291" x2="485" y2="291" stroke="#1a55bb" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr-grey)"/>
+  <!-- note: camera views die's bottom face through this cap -->
+  <text x="520" y="306" font-size="9" fill="#1a55bb" font-style="italic">(camera views die</text>
+  <text x="520" y="317" font-size="9" fill="#1a55bb" font-style="italic"> through this cap)</text>
+
+  <!-- ── Die ────────────────────────────────────────────────── -->
+  <!-- Die sits on TOP of acrylic; bottom edge at y=288 -->
+  <rect x="321" y="247" width="76" height="41" fill="white" stroke="#333" stroke-width="2" rx="8"/>
+  <!-- Pips — three across (simplified top face) -->
+  <circle cx="341" cy="267" r="4.5" fill="#222"/>
+  <circle cx="359" cy="267" r="4.5" fill="#222"/>
+  <circle cx="377" cy="267" r="4.5" fill="#222"/>
+  <!-- Die label -->
+  <text x="520" y="260" font-size="11" fill="#222" font-weight="bold">Die (d6)</text>
+  <line x1="516" y1="260" x2="399" y2="260" stroke="#555" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr-grey)"/>
+
+  <!-- ── Mirror (45°) ───────────────────────────────────────── -->
+  <!-- Reflection point: (359, 385); mirror at 45°, dx=dy=120    -->
+  <!-- Mirror line: (299, 445) → (419, 325)                      -->
+  <!-- Backing shadow (grey, offset +3,+2) -->
+  <line x1="302" y1="447" x2="422" y2="327" stroke="#b0b0b0" stroke-width="7" stroke-linecap="round"/>
+  <!-- Reflective surface (gold) -->
+  <line x1="299" y1="445" x2="419" y2="325" stroke="#e8c200" stroke-width="4.5" stroke-linecap="round"/>
+  <!-- Mirror label -->
+  <text x="142" y="442" font-size="11" fill="#9a7700" font-weight="bold">Mirror (45°)</text>
+  <text x="142" y="456" font-size="10" fill="#9a7700">first-surface</text>
+  <line x1="196" y1="449" x2="295" y2="444" stroke="#9a7700" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr-yellow)"/>
+
+  <!-- 45° angle arc at reflection point -->
+  <path d="M 379,385 A 24,24 0 0 1 359,365" fill="none" stroke="#9a7700" stroke-width="1.5"/>
+  <text x="367" y="378" font-size="9" fill="#9a7700">45°</text>
+
+  <!-- ── Camera ──────────────────────────────────────────────── -->
+  <!-- Body -->
+  <rect x="18" y="358" width="95" height="54" fill="#3a4e62" stroke="#1a2a3a" stroke-width="2" rx="7"/>
+  <!-- Barrel -->
+  <rect x="111" y="364" width="22" height="42" fill="#2a3e52" stroke="#1a2a3a" stroke-width="1.5" rx="3"/>
+  <!-- Lens glass -->
+  <ellipse cx="133" cy="385" rx="9" ry="14" fill="#111e2a" stroke="#8899aa" stroke-width="1.2"/>
+  <ellipse cx="133" cy="385" rx="4.5" ry="7" fill="#4a6888" opacity="0.75"/>
+  <!-- Camera label -->
+  <text x="65" y="391" text-anchor="middle" font-size="12" fill="white" font-weight="bold">Camera</text>
+  <!-- Sub-labels below body -->
+  <text x="65" y="430" text-anchor="middle" font-size="10" fill="#6a8aaa">horizontal mount</text>
+  <text x="65" y="443" text-anchor="middle" font-size="10" fill="#6a8aaa">global shutter</text>
+
+  <!-- Polarizer filter in front of lens -->
+  <rect x="140" y="364" width="5" height="42" fill="rgba(50,170,255,0.45)" stroke="#22aaee" stroke-width="1"/>
+  <text x="143" y="357" text-anchor="middle" font-size="9" fill="#0077bb">polarizer</text>
+  <line x1="143" y1="359" x2="143" y2="363" stroke="#0077bb" stroke-width="0.8"/>
+
+  <!-- ── Optical Path ────────────────────────────────────────── -->
+  <!-- Horizontal segment: polarizer → mirror (y=385) -->
+  <line x1="146" y1="385" x2="355" y2="385"
+        stroke="#e85000" stroke-width="2.5" stroke-dasharray="10,5"
+        marker-end="url(#arr-orange)"/>
+  <!-- Vertical segment: mirror → acrylic (x=359) -->
+  <line x1="359" y1="383" x2="359" y2="292"
+        stroke="#e85000" stroke-width="2.5" stroke-dasharray="10,5"
+        marker-end="url(#arr-orange)"/>
+  <!-- Axis labels -->
+  <text x="251" y="402" text-anchor="middle" font-size="10" fill="#b02800" font-style="italic">optical axis (horizontal)</text>
+  <text x="381" y="342" font-size="10" fill="#b02800" font-style="italic"
+        transform="rotate(90,381,342)">optical axis (reflected ↑)</text>
+
+  <!-- ── Diffuse Side Lighting ──────────────────────────────── -->
+  <!-- Three arrows entering from the right, aimed at die zone -->
+  <line x1="530" y1="252" x2="489" y2="263" stroke="#ffd633" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr-yellow)"/>
+  <line x1="530" y1="268" x2="489" y2="274" stroke="#ffd633" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr-yellow)"/>
+  <line x1="530" y1="284" x2="489" y2="284" stroke="#ffd633" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arr-yellow)"/>
+  <!-- Polarizer on light path (cross-polarizer) -->
+  <rect x="485" y="249" width="5" height="40" fill="rgba(50,170,255,0.4)" stroke="#22aaee" stroke-width="1"/>
+  <!-- Lighting labels -->
+  <text x="535" y="250" font-size="10" fill="#886600">Diffuse LED</text>
+  <text x="535" y="263" font-size="10" fill="#886600">lighting</text>
+  <text x="535" y="277" font-size="10" fill="#0077bb">+ polarizer</text>
+
+  <!-- ── Dimension Annotations ──────────────────────────────── -->
+  <!-- Horizontal leg dimension (camera to reflection point) -->
+  <line x1="146" y1="470" x2="359" y2="470" stroke="#999" stroke-width="1"/>
+  <line x1="146" y1="464" x2="146" y2="476" stroke="#999" stroke-width="1"/>
+  <line x1="359" y1="464" x2="359" y2="476" stroke="#999" stroke-width="1"/>
+  <text x="252" y="486" text-anchor="middle" font-size="9.5" fill="#666">horiz. leg min = 100.3 mm</text>
+
+  <!-- Vertical leg dimension (reflection point to acrylic) -->
+  <!-- Dashed connector lines extending to the right -->
+  <line x1="361" y1="288" x2="612" y2="288" stroke="#ccc" stroke-width="1" stroke-dasharray="4,3"/>
+  <line x1="361" y1="385" x2="612" y2="385" stroke="#ccc" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Dimension bar -->
+  <line x1="617" y1="288" x2="617" y2="385" stroke="#999" stroke-width="1"/>
+  <line x1="611" y1="288" x2="623" y2="288" stroke="#999" stroke-width="1"/>
+  <line x1="611" y1="385" x2="623" y2="385" stroke="#999" stroke-width="1"/>
+  <!-- Dimension text (rotated) -->
+  <text x="637" y="341" text-anchor="middle" font-size="9.5" fill="#666"
+        transform="rotate(90,637,341)">vert. leg min = 28.8 mm</text>
+
+  <!-- ── Legend ─────────────────────────────────────────────── -->
+  <rect x="544" y="415" width="166" height="118" fill="white" stroke="#ccc" stroke-width="1" rx="5"/>
+  <text x="627" y="433" text-anchor="middle" font-size="11" font-weight="bold" fill="#333">Legend</text>
+  <!-- Optical path -->
+  <line x1="553" y1="449" x2="584" y2="449" stroke="#e85000" stroke-width="2.5" stroke-dasharray="9,4"/>
+  <text x="590" y="452" font-size="10" fill="#333">Optical path</text>
+  <!-- Mirror -->
+  <line x1="553" y1="465" x2="584" y2="465" stroke="#e8c200" stroke-width="4.5"/>
+  <text x="590" y="468" font-size="10" fill="#333">Mirror (1st-surface)</text>
+  <!-- Acrylic -->
+  <line x1="553" y1="481" x2="584" y2="481" stroke="#4488dd" stroke-width="4.5" opacity="0.82"/>
+  <text x="590" y="484" font-size="10" fill="#333">Acrylic cap</text>
+  <!-- Polarizer -->
+  <rect x="553" y="491" width="31" height="9" fill="rgba(50,170,255,0.45)" stroke="#22aaee" stroke-width="1"/>
+  <text x="590" y="500" font-size="10" fill="#333">Cross-polarizer</text>
+  <!-- Lighting -->
+  <line x1="553" y1="516" x2="584" y2="516" stroke="#ffd633" stroke-width="2" stroke-dasharray="5,3"/>
+  <text x="590" y="519" font-size="10" fill="#333">Diffuse lighting</text>
+
+  <!-- ── Footer ─────────────────────────────────────────────── -->
+  <text x="360" y="548" text-anchor="middle" font-size="9" fill="#aaa">
+    Not to scale · schematic view only
+  </text>
+
+</svg>

--- a/Hardware/optical_viz.html
+++ b/Hardware/optical_viz.html
@@ -1,0 +1,807 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Die Tester – Optical Path Visualizer</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; font-family: Arial, sans-serif; }
+    body { display: flex; background: #0d1117; }
+
+    /* ── Sidebar ──────────────────────────────────────────────────── */
+    #sidebar {
+      width: 400px; flex-shrink: 0;
+      background: #0d1117; border-right: 1px solid rgba(255,255,255,0.08);
+      overflow-y: auto; padding: 28px 26px 48px;
+      color: #c8d4e0; font-size: 13px; line-height: 1.75;
+    }
+    #sidebar h1 {
+      font-size: 16px; font-weight: 700; color: #e8f0fa;
+      margin-bottom: 4px; letter-spacing: 0.01em;
+    }
+    #sidebar .subtitle {
+      font-size: 11px; color: #667788; margin-bottom: 22px;
+      letter-spacing: 0.04em; text-transform: uppercase;
+    }
+    #sidebar h2 {
+      font-size: 13px; font-weight: 700; color: #88bbdd;
+      margin: 22px 0 8px; letter-spacing: 0.03em;
+      text-transform: uppercase; font-size: 11px;
+      border-bottom: 1px solid rgba(136,187,221,0.2); padding-bottom: 4px;
+    }
+    #sidebar h3 {
+      font-size: 12px; font-weight: 700; color: #aaccee;
+      margin: 14px 0 4px;
+    }
+    #sidebar p { margin-bottom: 10px; }
+    #sidebar table {
+      width: 100%; border-collapse: collapse; font-size: 11.5px;
+      margin: 8px 0 14px;
+    }
+    #sidebar th {
+      text-align: left; color: #88aacc; font-weight: 600;
+      padding: 4px 6px; border-bottom: 1px solid rgba(255,255,255,0.12);
+    }
+    #sidebar td {
+      padding: 5px 6px; border-bottom: 1px solid rgba(255,255,255,0.05);
+      vertical-align: top;
+    }
+    #sidebar td:first-child { color: #aaccee; white-space: nowrap; }
+    #sidebar td:nth-child(2) { color: #e8f0fa; font-family: monospace; white-space: nowrap; }
+    #sidebar .note {
+      font-size: 11px; color: #667788; border-left: 2px solid rgba(136,187,221,0.3);
+      padding: 6px 10px; margin: 10px 0; background: rgba(136,187,221,0.05);
+      border-radius: 0 4px 4px 0;
+    }
+    #sidebar .swatch { display: inline-block; width: 9px; height: 9px;
+                       border-radius: 2px; margin-right: 5px; vertical-align: middle; }
+
+    /* ── Canvas container ─────────────────────────────────────────── */
+    #canvas-wrap { flex: 1; position: relative; overflow: hidden; }
+    #canvas-wrap canvas { display: block; width: 100% !important; height: 100% !important; }
+
+    #overlay {
+      position: absolute; top: 14px; left: 14px; z-index: 10;
+      background: rgba(0,0,0,0.6); backdrop-filter: blur(6px);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 8px; padding: 10px 14px;
+      color: #cdd6e0; font-size: 11px; line-height: 1.7;
+      pointer-events: none;
+    }
+    #overlay strong { color: #fff; font-size: 12px; display: block; margin-bottom: 3px; }
+    #overlay .sep { border-top: 1px solid rgba(255,255,255,0.12); margin: 5px 0; }
+    #overlay .swatch { display: inline-block; width: 9px; height: 9px;
+                       border-radius: 2px; margin-right: 4px; vertical-align: middle; }
+
+    /* 3-D projected labels */
+    #labels { position: absolute; top: 0; left: 0; pointer-events: none; }
+    .lbl {
+      position: absolute; transform: translate(-50%, -50%);
+      font-size: 11px; font-family: Arial, sans-serif;
+      background: rgba(10,14,22,0.7); border-radius: 4px;
+      padding: 2px 7px; pointer-events: none; white-space: nowrap;
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+
+    /* Slider controls panel */
+    #controls {
+      position: absolute; top: 14px; right: 14px; z-index: 10;
+      background: rgba(0,0,0,0.6); backdrop-filter: blur(6px);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 8px; padding: 14px 18px;
+      color: #cdd6e0; font-size: 12px; min-width: 260px;
+    }
+    #controls strong { color: #fff; font-size: 13px; display: block; margin-bottom: 10px; }
+    #controls .row { display: flex; align-items: center; margin-bottom: 8px; gap: 8px; }
+    #controls .row label { flex: 0 0 140px; color: #aabbcc; }
+    #controls input[type=range] { flex: 1; cursor: pointer; accent-color: #44bbdd; }
+    #controls .val { flex: 0 0 56px; text-align: right; font-family: monospace;
+                     color: #aaccee; font-size: 11px; }
+    #controls .divider { border: none; border-top: 1px solid rgba(255,255,255,0.1); margin: 10px 0 8px; }
+    #controls button {
+      width: 100%; padding: 6px 0; cursor: pointer; font-size: 11px;
+      background: rgba(68,187,221,0.12); border: 1px solid rgba(68,187,221,0.35);
+      border-radius: 5px; color: #88ddee; letter-spacing: 0.04em;
+    }
+    #controls button:hover { background: rgba(68,187,221,0.28); color: #cceeff; }
+  </style>
+</head>
+<body>
+
+<!-- ══════════════════════════════════════════════════════════════════════════
+     SIDEBAR — explanatory text
+     ══════════════════════════════════════════════════════════════════════ -->
+<div id="sidebar">
+
+  <h1>Die Tester &mdash; Optical Path</h1>
+  <div class="subtitle">Folded camera &rarr; mirror &rarr; tower</div>
+
+  <h2>How the system works</h2>
+  <p>The camera is mounted horizontally, pointing along the X axis toward a
+  45&deg; first-surface mirror sitting at the origin. The mirror folds the
+  optical path 90&deg; upward into a vertical cylindrical tower. A die
+  resting at the base of the tower is photographed from below, through the
+  mirror, without the camera needing a clear vertical line of sight.</p>
+
+  <h2>Why not just centre everything?</h2>
+  <p>The instinctive layout — camera optical axis level with the mirror centre,
+  tower centred directly above — turns out not to be optimal. Three geometric
+  effects make deliberate offsets necessary.</p>
+
+  <h3>1. The FOV footprint on the mirror is a trapezoid</h3>
+  <p>Corner rays aimed slightly <em>upward</em> travel further before striking
+  the 45&deg; mirror plane (y&nbsp;=&nbsp;x) than corner rays aimed slightly
+  <em>downward</em>. The footprint is therefore wider at the top of the mirror
+  and narrower at the bottom &mdash; a trapezoid, not a rectangle. This
+  asymmetry is baked into the geometry and exists even when the camera is
+  perfectly centred.</p>
+
+  <h3>2. Camera Y offset (&minus;14&thinsp;mm)</h3>
+  <p>With the camera at Y&nbsp;=&nbsp;0 the reflected optical axis goes
+  straight up through the mirror centre. But the trapezoidal distortion means
+  the <em>centroid</em> of the four reflected FOV corners is not at the same
+  point as the optical axis. Dropping the camera 14&thinsp;mm below the mirror
+  centre shifts the footprint so that after reflection the image is positioned
+  symmetrically over the 3.75&Prime; capture disc at the tower base.</p>
+
+  <h3>3. Tower X offset (&minus;5&thinsp;mm)</h3>
+  <p>Once the camera is offset in Y, its optical axis hits the mirror at
+  (y,&thinsp;y,&thinsp;0) where y&nbsp;=&nbsp;camY, and the reflected axis
+  emerges at that same X coordinate &mdash; not at X&nbsp;=&nbsp;0. The
+  <em>spread</em> of the four reflected corner rays around that axis is also
+  asymmetric. Empirically, placing the tower centre 5&thinsp;mm to the left
+  aligns the 3.75&Prime; capture ring within the reflected FOV with the
+  smallest margin wasted on either side.</p>
+
+  <h3>4. Horizontal leg &amp; mirror fill (116&thinsp;mm)</h3>
+  <p>Camera distance controls resolution vs. coverage. Too close: the FOV
+  extends past the mirror edges, wasting pixels on the mirror frame. Too far:
+  the mirror underfills the FOV, reducing resolution on the die. At
+  116&thinsp;mm the top and bottom edges of the vertical FOV align exactly
+  with the top and bottom of the mirror face &mdash; every pixel captured is
+  useful reflected image.</p>
+
+  <h3>5. Tower bottom Y (139&thinsp;mm)</h3>
+  <p>The tower must clear the mirror&rsquo;s highest point (~42&thinsp;mm)
+  with a safety margin. At 139&thinsp;mm the die entrance sits high enough to
+  avoid collision while still being well within the reflected FOV cone.</p>
+
+  <h2>Preset values</h2>
+  <table>
+    <tr><th>Parameter</th><th>Value</th><th>Rationale</th></tr>
+    <tr><td>Horiz. leg</td><td>116 mm</td><td>Mirror fills vertical FOV</td></tr>
+    <tr><td>Camera Y offset</td><td>&minus;14 mm</td><td>Centers reflected image over capture disc</td></tr>
+    <tr><td>Tower X offset</td><td>&minus;5 mm</td><td>Aligns disc within reflected FOV</td></tr>
+    <tr><td>Tower bottom Y</td><td>139 mm</td><td>Clears mirror with margin</td></tr>
+    <tr><td>Mirror</td><td>160&times;115&times;3 mm</td><td>First-surface, 45&deg;</td></tr>
+    <tr><td>Camera FOV</td><td>50&deg;&thinsp;H &times; 38&deg;&thinsp;V</td><td>Sensor specification</td></tr>
+    <tr><td>Capture target</td><td>3.75&Prime; dia</td><td>Red ring at tower base</td></tr>
+    <tr><td>Tower</td><td>5&Prime; dia &times; 6&Prime; tall</td><td>Outer boundary</td></tr>
+  </table>
+
+  <h2>Colour key</h2>
+  <p>
+    <span class="swatch" style="background:#ffcc00"></span>Mirror face (45&deg;)<br>
+    <span class="swatch" style="background:#e85000"></span>Optical axis<br>
+    <span class="swatch" style="background:#ffe066"></span>FOV cone &amp; mirror footprint<br>
+    <span class="swatch" style="background:#44ddcc"></span>Reflected FOV cone<br>
+    <span class="swatch" style="background:#3a506b"></span>Dice tower (5&Prime; dia)<br>
+    <span class="swatch" style="background:#ff2020"></span>3.75&Prime; capture target<br>
+    <span class="swatch" style="background:#ff8844"></span>Mirror-to-tower clearance<br>
+  </p>
+
+  <h2>Controls</h2>
+  <p>Use the sliders (top-right of the 3D view) to explore how changing each
+  parameter affects coverage and clearance. The <em>Mirror-fill preset</em>
+  button snaps back to the values above. Drag to orbit, scroll to zoom,
+  right-drag to pan.</p>
+
+  <div class="note">The mirror reflection in the 3D view is live &mdash; the
+  red capture ring and reflected FOV cone visible in the mirror face show
+  exactly what the physical camera will see.</div>
+
+</div><!-- #sidebar -->
+
+<!-- ══════════════════════════════════════════════════════════════════════════
+     CANVAS WRAP — 3D visualiser
+     ══════════════════════════════════════════════════════════════════════ -->
+<div id="canvas-wrap">
+
+<div id="overlay">
+  <strong>Drag: orbit &nbsp;&middot;&nbsp; Scroll: zoom &nbsp;&middot;&nbsp; Right-drag: pan</strong>
+  <div class="sep"></div>
+  <span class="swatch" style="background:#ffe066"></span> FOV cone &mdash; 50&deg;&thinsp;H &times; 38&deg;&thinsp;V<br>
+  <span class="swatch" style="background:#44ddcc"></span> Reflected FOV cone<br>
+  <span class="swatch" style="background:#ff2020"></span> 3.75&Prime; capture target<br>
+  <span style="font-size:10px; color:#889aaa;">
+    Z axis &nbsp;&middot;&nbsp; Y&nbsp;=&nbsp;up/tower &nbsp;&middot;&nbsp; X axis
+  </span>
+</div>
+
+<div id="labels"></div>
+
+<div id="controls">
+  <strong>Scene controls</strong>
+  <div class="row"><label>Tower X offset</label>
+    <input type="range" id="towerX" min="-150" max="150" value="-5" step="1">
+    <span class="val" id="towerXVal">-5 mm</span></div>
+  <div class="row"><label>Tower bottom Y</label>
+    <input type="range" id="towerBotY" min="20" max="200" value="139" step="1">
+    <span class="val" id="towerBotYVal">139 mm</span></div>
+  <div class="row"><label>Camera horiz. leg</label>
+    <input type="range" id="horizLeg" min="50" max="400" value="116" step="1">
+    <span class="val" id="horizLegVal">116 mm</span></div>
+  <div class="row"><label>Camera Y offset</label>
+    <input type="range" id="camY" min="-80" max="80" value="-14" step="1">
+    <span class="val" id="camYVal">-14 mm</span></div>
+  <hr class="divider">
+  <button id="presetMirrorFill">⟳&nbsp; Mirror-fill preset</button>
+</div>
+
+</div><!-- #canvas-wrap -->
+
+<script type="importmap">
+{
+  "imports": {
+    "three":          "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+    "three/addons/":  "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { Reflector }     from 'three/addons/objects/Reflector.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scene constants (all dimensions in mm)
+// ─────────────────────────────────────────────────────────────────────────────
+const MIRROR = { w: 160, h: 115, d: 3 };
+//   w = 160 mm  → along Z axis (width / depth direction)
+//   h = 115 mm  → along the mirror surface (at 45° in the XY plane)
+//   d =   3 mm  → mirror thickness (along mirror normal)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Physical constants (fixed geometry)
+// ─────────────────────────────────────────────────────────────────────────────
+const TOWER        = { r: 63.5, h: 152.4 };                              // 5" dia, 6" tall
+const MIRROR_TOP_Y = (MIRROR.h / 2 + MIRROR.d / 2) / Math.SQRT2;        // ~41.7 mm
+
+const FOV_H_DEG = 50, FOV_V_DEG = 38;
+const hH = Math.tan((FOV_H_DEG / 2) * Math.PI / 180);   // half-width  ratio
+const hV = Math.tan((FOV_V_DEG / 2) * Math.PI / 180);   // half-height ratio
+// Corner order: 0=top-right  1=top-left  2=bottom-left  3=bottom-right
+const fovVY = [ hV,  hV, -hV, -hV];
+const fovVZ = [ hH, -hH, -hH,  hH];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutable scene parameters  (driven by the slider controls)
+// ─────────────────────────────────────────────────────────────────────────────
+const params = {
+  horizLeg:  116,   // mm — camera → mirror horizontal distance
+  camY:      -14,   // mm — camera optical axis Y offset
+  towerX:     -5,   // mm — tower centre X offset
+  towerBotY: 139,   // mm — tower bottom face Y height
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Renderer
+// ─────────────────────────────────────────────────────────────────────────────
+const wrap = document.getElementById('canvas-wrap');
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(wrap.clientWidth, wrap.clientHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+wrap.appendChild(renderer.domElement);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scene
+// ─────────────────────────────────────────────────────────────────────────────
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x12161f);
+scene.fog = new THREE.FogExp2(0x12161f, 0.0008);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Perspective camera (Three.js camera — not the physical camera)
+// ─────────────────────────────────────────────────────────────────────────────
+const cam = new THREE.PerspectiveCamera(
+  45,
+  wrap.clientWidth / wrap.clientHeight,
+  1, 3000
+);
+// Pulled back to frame camera, mirror, and the full tower height (~200 mm)
+cam.position.set(-80, 440, 580);
+cam.lookAt(0, 100, 0);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orbit controls
+// ─────────────────────────────────────────────────────────────────────────────
+const controls = new OrbitControls(cam, renderer.domElement);
+controls.enableDamping  = true;
+controls.dampingFactor  = 0.07;
+controls.minDistance    = 80;
+controls.maxDistance    = 2400;
+controls.target.set(0, 100, 0);
+// Layer 1 = "display only" — visible to the main camera but NOT to the
+// Reflector's internal camera (which defaults to layer 0 only).
+cam.layers.enable(1);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lighting
+// ─────────────────────────────────────────────────────────────────────────────
+scene.add(new THREE.AmbientLight(0xffffff, 0.55));
+
+const keyLight = new THREE.DirectionalLight(0xffffff, 1.3);
+keyLight.position.set(250, 450, 300);
+scene.add(keyLight);
+
+const fillLight = new THREE.DirectionalLight(0x8899cc, 0.4);
+fillLight.position.set(-200, 80, -150);
+scene.add(fillLight);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reference grid  (XZ horizontal plane — "floor")
+// ─────────────────────────────────────────────────────────────────────────────
+const grid = new THREE.GridHelper(700, 28, 0x243040, 0x1a2530);
+scene.add(grid);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Axis arrows  (X=red, Y=green, Z=blue)
+// ─────────────────────────────────────────────────────────────────────────────
+const AXIS_LEN = 130;
+scene.add(new THREE.AxesHelper(AXIS_LEN));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Origin sphere
+// ─────────────────────────────────────────────────────────────────────────────
+scene.add(new THREE.Mesh(
+  new THREE.SphereGeometry(4, 24, 24),
+  new THREE.MeshBasicMaterial({ color: 0xff3333 })
+));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mirror
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Build as BoxGeometry(MIRROR.h, MIRROR.d, MIRROR.w) oriented flat (normals ±Y),
+// then rotate the group +45° around Z so that:
+//
+//   local +Y  →  world (-√2/2, +√2/2, 0)  ← mirror normal, faces upper-left
+//   local +X  →  world (+√2/2, +√2/2, 0)  ← mirror length, runs lower-left → upper-right
+//   local +Z  →  world (0, 0, 1)           ← mirror width, unchanged
+//
+// A horizontal ray travelling in +X reflects off the upper-left face → exits in +Y. ✓
+//
+// BoxGeometry face material indices:
+//   0 = +X,  1 = −X,  2 = +Y (reflective),  3 = −Y (backing),  4 = +Z,  5 = −Z
+// ─────────────────────────────────────────────────────────────────────────────
+const mirrorGroup = new THREE.Group();
+
+const matEdge = new THREE.MeshStandardMaterial({ color: 0x778899, roughness: 0.7, metalness: 0.3 });
+const matBack = new THREE.MeshStandardMaterial({ color: 0x445566, roughness: 0.9, metalness: 0.1 });
+const matRefl = new THREE.MeshStandardMaterial({ color: 0xd4be55, roughness: 0.06, metalness: 0.95 });
+
+const mirrorGeo  = new THREE.BoxGeometry(MIRROR.h, MIRROR.d, MIRROR.w);
+const mirrorMesh = new THREE.Mesh(mirrorGeo, [
+  matEdge,   // +X right edge
+  matEdge,   // −X left edge
+  matRefl,   // +Y  ← reflective face (will face upper-left after tilt)
+  matBack,   // −Y  ← backing
+  matEdge,   // +Z
+  matEdge,   // −Z
+]);
+mirrorGroup.add(mirrorMesh);
+
+// Gold outline on all edges
+mirrorGroup.add(new THREE.LineSegments(
+  new THREE.EdgesGeometry(mirrorGeo),
+  new THREE.LineBasicMaterial({ color: 0xffcc00 })
+));
+
+// Tilt 45° around Z
+mirrorGroup.rotation.z = Math.PI / 4;
+scene.add(mirrorGroup);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mirror normal arrow  (shows reflective-face direction: upper-left)
+// ─────────────────────────────────────────────────────────────────────────────
+const normalDir = new THREE.Vector3(-1, 1, 0).normalize();
+scene.add(new THREE.ArrowHelper(
+  normalDir,
+  new THREE.Vector3(0, 0, 0),   // origin
+  45,                            // length
+  0xffee44,                      // colour
+  10, 6                          // head length, head width
+));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Physical camera
+//
+// HORIZ_LEG: distance along X from the lens front to the mirror centre.
+// The lens front sits at world X = -HORIZ_LEG; all camera parts are defined
+// relative to that point (local X = 0 → lens front).
+// ─────────────────────────────────────────────────────────────────────────────
+const matCamBody   = new THREE.MeshStandardMaterial({ color: 0x2e3f52, roughness: 0.55, metalness: 0.35 });
+const matCamBarrel = new THREE.MeshStandardMaterial({ color: 0x1c2b38, roughness: 0.45, metalness: 0.55 });
+const matCamGlass  = new THREE.MeshStandardMaterial({ color: 0x3a5878, roughness: 0.05, metalness: 0.9,
+                                                      transparent: true, opacity: 0.78 });
+const matCamEdge   = new THREE.LineBasicMaterial({ color: 0x44637a });
+
+const camGroup = new THREE.Group();
+camGroup.position.set(-params.horizLeg, params.camY, 0);
+
+// — Lens barrel (CylinderGeometry is Y-aligned → rotate 90° around Z for X-alignment)
+const BARREL = { r: 11, len: 22 };
+const barrelGeo  = new THREE.CylinderGeometry(BARREL.r, BARREL.r + 2, BARREL.len, 32);
+const barrelMesh = new THREE.Mesh(barrelGeo, matCamBarrel);
+barrelMesh.rotation.z = Math.PI / 2;
+barrelMesh.position.set(-BARREL.len / 2, 0, 0);   // front face at local X = 0
+camGroup.add(barrelMesh);
+
+// — Lens glass disc at the front face (local X = 0, facing +X)
+const glassMesh = new THREE.Mesh(new THREE.CircleGeometry(9, 40), matCamGlass);
+glassMesh.rotation.y = -Math.PI / 2;              // CircleGeometry faces +Z → rotate to face +X
+camGroup.add(glassMesh);
+
+// — Camera body box (sits directly behind the barrel)
+const BODY = { x: 50, y: 44, z: 54 };
+const bodyGeo  = new THREE.BoxGeometry(BODY.x, BODY.y, BODY.z);
+const bodyMesh = new THREE.Mesh(bodyGeo, matCamBody);
+bodyMesh.position.set(-(BARREL.len + BODY.x / 2), 0, 0);
+camGroup.add(bodyMesh);
+
+const bodyEdges = new THREE.LineSegments(new THREE.EdgesGeometry(bodyGeo), matCamEdge);
+bodyEdges.position.copy(bodyMesh.position);
+camGroup.add(bodyEdges);
+
+// — Small lens ring (torus around the barrel front, indicates polariser)
+const ringMesh = new THREE.Mesh(
+  new THREE.TorusGeometry(BARREL.r + 1.5, 2, 12, 40),
+  new THREE.MeshStandardMaterial({ color: 0x4499cc, roughness: 0.3, metalness: 0.5,
+                                    transparent: true, opacity: 0.7 })
+);
+ringMesh.rotation.y = Math.PI / 2;   // face the ring toward +X
+camGroup.add(ringMesh);
+
+scene.add(camGroup);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dynamic scene groups  (cleared + rebuilt on every slider change)
+// ─────────────────────────────────────────────────────────────────────────────
+const fovGroup   = new THREE.Group();
+const towerGroup = new THREE.Group();
+scene.add(fovGroup);
+scene.add(towerGroup);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rebuildScene()  — reconstructs all slider-dependent geometry and updates
+// label positions / text.  Called once at startup and on every slider event.
+// ─────────────────────────────────────────────────────────────────────────────
+function rebuildScene() {
+  camGroup.position.set(-params.horizLeg, params.camY, 0);
+  fovGroup.clear();
+  towerGroup.clear();
+
+  // Derived tower locals
+  const TOWER_BOT = params.towerBotY;
+  const TOWER_TOP = params.towerBotY + TOWER.h;
+  const TOWER_CEN = params.towerBotY + TOWER.h / 2;
+  const GAP_X     = TOWER.r + 14;
+  const clearance = params.towerBotY - MIRROR_TOP_Y;
+
+  // ── Horizontal optical axis ──────────────────────────────────────────────
+  fovGroup.add(new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(-params.horizLeg, params.camY, 0),
+      new THREE.Vector3(0, params.camY, 0),
+    ]),
+    new THREE.LineBasicMaterial({ color: 0xe85000 })
+  ));
+  fovGroup.add(new THREE.ArrowHelper(
+    new THREE.Vector3(1, 0, 0),
+    new THREE.Vector3(-20, params.camY, 0),
+    20, 0xe85000, 8, 5
+  ));
+
+  // ── FOV cone ─────────────────────────────────────────────────────────────
+  // Generalised mirror intersection for camera at height camY:
+  //   ray(t) = (-horizLeg + t,  camY + vy*t,  vz*t)
+  //   hit y=x:  camY + vy*t = -horizLeg + t  →  t = (horizLeg + camY) / (1 - vy)
+  const lensWorld  = new THREE.Vector3(-params.horizLeg, params.camY, 0);
+  const mirrorHits = fovVY.map((vy, i) => {
+    const t = (params.horizLeg + params.camY) / (1 - vy);
+    return new THREE.Vector3(-params.horizLeg + t, params.camY + vy * t, fovVZ[i] * t);
+  });
+
+  // Edge lines — layer 1 (excluded from Reflector)
+  const matFovLine = new THREE.LineBasicMaterial({ color: 0xffe066, transparent: true, opacity: 0.75 });
+  mirrorHits.forEach(hit => {
+    const l = new THREE.Line(new THREE.BufferGeometry().setFromPoints([lensWorld, hit]), matFovLine);
+    l.layers.set(1);
+    fovGroup.add(l);
+  });
+
+  // Pyramid volume — layer 1
+  {
+    const [h0, h1, h2, h3] = mirrorHits;
+    const verts = [
+      lensWorld, h0, h1,   lensWorld, h1, h2,   lensWorld, h2, h3,   lensWorld, h3, h0,
+      h0, h3, h2,           h0, h2, h1,
+    ].flatMap(v => [v.x, v.y, v.z]);
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));
+    const m = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({
+      color: 0xffe066, transparent: true, opacity: 0.07,
+      side: THREE.DoubleSide, depthWrite: false,
+    }));
+    m.layers.set(1);
+    fovGroup.add(m);
+  }
+
+  // Footprint trapezoid: fill = layer 1, outline = layer 0 (shows in Reflector)
+  {
+    const nOff = new THREE.Vector3(-1, 1, 0).normalize().multiplyScalar(3);
+    const [h0, h1, h2, h3] = mirrorHits.map(p => p.clone().add(nOff));
+    const fillVerts = [h0, h3, h2, h0, h2, h1].flatMap(v => [v.x, v.y, v.z]);
+    const fillGeo   = new THREE.BufferGeometry();
+    fillGeo.setAttribute('position', new THREE.Float32BufferAttribute(fillVerts, 3));
+    const fillMesh = new THREE.Mesh(fillGeo, new THREE.MeshBasicMaterial({
+      color: 0xffe066, transparent: true, opacity: 0.38,
+      side: THREE.DoubleSide, depthWrite: false,
+    }));
+    fillMesh.layers.set(1);
+    fovGroup.add(fillMesh);
+    fovGroup.add(new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([h0, h1, h2, h3, h0]),
+      new THREE.LineBasicMaterial({ color: 0xffffbb })
+    ));
+  }
+
+  // ── Reflected FOV cone ───────────────────────────────────────────────────
+  {
+    const matRF = new THREE.LineBasicMaterial({ color: 0x44ddcc, transparent: true, opacity: 0.9 });
+    const reflEnds = mirrorHits.map((hit, i) => {
+      const t = TOWER_TOP - hit.y;
+      return new THREE.Vector3(hit.x + fovVY[i] * t, TOWER_TOP, hit.z + fovVZ[i] * t);
+    });
+    mirrorHits.forEach((hit, i) =>
+      fovGroup.add(new THREE.Line(
+        new THREE.BufferGeometry().setFromPoints([hit, reflEnds[i]]),
+        matRF
+      ))
+    );
+    const [e0, e1, e2, e3] = reflEnds;
+    fovGroup.add(new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([e0, e1, e2, e3, e0]),
+      matRF
+    ));
+    const reflFpBot = mirrorHits.map((hit, i) => {
+      const t = TOWER_BOT - hit.y;
+      return new THREE.Vector3(hit.x + fovVY[i] * t, TOWER_BOT, hit.z + fovVZ[i] * t);
+    });
+    const [rb0, rb1, rb2, rb3] = reflFpBot;
+    const botVerts = [rb0, rb3, rb2, rb0, rb2, rb1].flatMap(v => [v.x, v.y, v.z]);
+    const botGeo   = new THREE.BufferGeometry();
+    botGeo.setAttribute('position', new THREE.Float32BufferAttribute(botVerts, 3));
+    fovGroup.add(new THREE.Mesh(botGeo, new THREE.MeshBasicMaterial({
+      color: 0x44ddcc, transparent: true, opacity: 0.15,
+      side: THREE.DoubleSide, depthWrite: false,
+    })));
+    fovGroup.add(new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([rb0, rb1, rb2, rb3, rb0]),
+      matRF
+    ));
+  }
+
+  // ── Dice tower ───────────────────────────────────────────────────────────
+  // Reflected vertical optical ray
+  towerGroup.add(new THREE.ArrowHelper(
+    new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 0),
+    TOWER_BOT, 0xe85000, 8, 5
+  ));
+  // Cylinder body
+  const towerMesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(TOWER.r, TOWER.r, TOWER.h, 64, 1, true),
+    new THREE.MeshStandardMaterial({
+      color: 0x3a506b, roughness: 0.6, metalness: 0.15,
+      transparent: true, opacity: 0.28, side: THREE.DoubleSide,
+    })
+  );
+  towerMesh.position.set(0, TOWER_CEN, 0);
+  towerGroup.add(towerMesh);
+  // Edge rings
+  const matRing = new THREE.MeshStandardMaterial({ color: 0x6a8aab, roughness: 0.5, metalness: 0.5 });
+  [TOWER_BOT, TOWER_TOP].forEach(y => {
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(TOWER.r, 1.8, 8, 64), matRing);
+    ring.position.set(0, y, 0);
+    ring.rotation.x = Math.PI / 2;
+    towerGroup.add(ring);
+  });
+  // Capture-area target at tower base: 3.75" (95.25 mm) dia — must be fully in FOV
+  // Layer 0 so it appears in the mirror reflection as well as the main view
+  const CAP_R = (3.75 * 25.4) / 2;   // 47.625 mm
+  const captureRing = new THREE.Mesh(
+    new THREE.TorusGeometry(CAP_R, 2, 8, 128),
+    new THREE.MeshBasicMaterial({ color: 0xff2020 })
+  );
+  captureRing.position.set(0, TOWER_BOT, 0);
+  captureRing.rotation.x = Math.PI / 2;
+  towerGroup.add(captureRing);
+  const captureDisc = new THREE.Mesh(
+    new THREE.CircleGeometry(CAP_R, 128),
+    new THREE.MeshBasicMaterial({
+      color: 0xff2020, transparent: true, opacity: 0.12,
+      side: THREE.DoubleSide, depthWrite: false,
+    })
+  );
+  captureDisc.position.set(0, TOWER_BOT, 0);
+  captureDisc.rotation.x = -Math.PI / 2;
+  towerGroup.add(captureDisc);
+  // Clearance gap indicator
+  const matGap = new THREE.LineBasicMaterial({ color: 0xff8844 });
+  towerGroup.add(new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(GAP_X, MIRROR_TOP_Y, 0),
+      new THREE.Vector3(GAP_X, TOWER_BOT,   0),
+    ]),
+    matGap
+  ));
+  [MIRROR_TOP_Y, TOWER_BOT].forEach(y =>
+    towerGroup.add(new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([
+        new THREE.Vector3(GAP_X - 5, y, 0),
+        new THREE.Vector3(GAP_X + 5, y, 0),
+      ]),
+      matGap
+    ))
+  );
+  // Offset the whole tower group in X
+  towerGroup.position.set(params.towerX, 0, 0);
+
+  // ── Update dynamic label positions and text ──────────────────────────────
+  if (!labelEls) return;   // guard: labelEls created after first rebuildScene call
+  const _topW   = Math.round(Math.abs(mirrorHits[0].z - mirrorHits[1].z));
+  const _botW   = Math.round(Math.abs(mirrorHits[3].z - mirrorHits[2].z));
+  const _topCtr = mirrorHits[0].clone().add(mirrorHits[1]).multiplyScalar(0.5);
+  const _botCtr = mirrorHits[2].clone().add(mirrorHits[3]).multiplyScalar(0.5);
+  const _trapH  = Math.round(_topCtr.distanceTo(_botCtr));
+
+  LABELS[5].pos.set(-(params.horizLeg + BODY.x / 2), params.camY - 42, 0);
+  LABELS[6].pos.set(-params.horizLeg / 2, params.camY + 12, 0);
+  LABELS[6].text = `horiz. leg  ${params.horizLeg} mm`;
+  labelEls[6].innerText = LABELS[6].text;
+  LABELS[7].pos.copy(mirrorHits[0].clone().add(new THREE.Vector3(8, 26, 6)));
+  LABELS[7].text = `FOV footprint\ntop: ${_topW} mm wide\nbottom: ${_botW} mm wide\n${_trapH} mm along mirror`;
+  labelEls[7].innerText = LABELS[7].text;
+  LABELS[8].pos.set(params.towerX + TOWER.r + 22, TOWER_CEN, 0);
+  LABELS[9].pos.set(params.towerX + GAP_X + 20, (MIRROR_TOP_Y + TOWER_BOT) / 2, 0);
+  LABELS[9].text = `${Math.round(clearance)} mm\nclearance`;
+  labelEls[9].innerText = LABELS[9].text;
+  LABELS[10].pos.set(params.towerX + 10, TOWER_BOT / 2, 0);
+  LABELS[10].text = `vert. leg\n~${TOWER_BOT} mm`;
+  labelEls[10].innerText = LABELS[10].text;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mirror face — real-time reflection  (Three.js Reflector)
+//
+// Reflector renders the scene from the virtual camera (the viewer camera
+// reflected across the 45° mirror plane) and paints the result as a live
+// texture directly on the mirror face.  Orbit to the camera side and you
+// will see the tower and scene reflected in the mirror.
+// ─────────────────────────────────────────────────────────────────────────────
+const mirrorReflector = new Reflector(
+  new THREE.PlaneGeometry(MIRROR.h, MIRROR.w),
+  {
+    clipBias:     0.0003,
+    textureWidth:  Math.min(wrap.clientWidth  * window.devicePixelRatio, 2048),
+    textureHeight: Math.min(wrap.clientHeight * window.devicePixelRatio, 2048),
+    color:        0xddcc88,   // warm gold tint matching the mirror
+  }
+);
+// Add to mirrorGroup so it inherits the 45° world tilt automatically.
+// In group-local space the reflective face is the +Y face, so:
+//   rotation.x = -PI/2  →  PlaneGeometry normal (+Z) flips to point along local +Y
+//   position.y = MIRROR.d/2 + 1.5  →  sits just in front of the gold BoxGeometry face
+mirrorReflector.rotation.x = -Math.PI / 2;
+mirrorReflector.position.set(0, MIRROR.d / 2 + 1.5, 0);
+mirrorGroup.add(mirrorReflector);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3-D label system
+// ─────────────────────────────────────────────────────────────────────────────
+const labelContainer = document.getElementById('labels');
+
+const LABELS = [
+  { pos: new THREE.Vector3(AXIS_LEN + 10, 0,            0), text: 'Z axis',           color: '#ff6666' },
+  { pos: new THREE.Vector3(0,            AXIS_LEN + 10, 0), text: 'Y  (up / tower)',   color: '#44ee88' },
+  { pos: new THREE.Vector3(0,            0, AXIS_LEN + 10), text: 'X axis',           color: '#5599ff' },
+  { pos: new THREE.Vector3(-55, 60, 0),                     text: 'Mirror\n160×115×3 mm · 45°\nfirst-surface', color: '#ffcc00' },
+  { pos: new THREE.Vector3(-20, -10, 0),                    text: 'origin',            color: '#ff8888' },
+  // indices 5–10: positions/text updated dynamically by rebuildScene()
+  { pos: new THREE.Vector3(0, 0, 0), text: 'Camera\nhorizontal mount',   color: '#7aafd4' },
+  { pos: new THREE.Vector3(0, 0, 0), text: 'horiz. leg',                 color: '#e87030' },
+  { pos: new THREE.Vector3(0, 0, 0), text: 'FOV footprint',              color: '#ffe588' },
+  { pos: new THREE.Vector3(0, 0, 0), text: `Dice tower\nø${Math.round(TOWER.r * 2)} mm (5") × ${Math.round(TOWER.h)} mm (6")`, color: '#8aaccc' },
+  { pos: new THREE.Vector3(0, 0, 0), text: 'clearance',                  color: '#ff8844' },
+  { pos: new THREE.Vector3(0, 0, 0), text: 'vert. leg',                  color: '#e87030' },
+];
+
+let labelEls = LABELS.map(d => {
+  const el = document.createElement('div');
+  el.className = 'lbl';
+  el.style.color = d.color;
+  el.innerText   = d.text;
+  labelContainer.appendChild(el);
+  return el;
+});
+
+function updateLabels() {
+  const W = wrap.clientWidth, H = wrap.clientHeight;
+  LABELS.forEach((d, i) => {
+    const v  = d.pos.clone().project(cam);
+    const sx = (v.x *  0.5 + 0.5) * W;
+    const sy = (v.y * -0.5 + 0.5) * H;
+    labelEls[i].style.left    = sx + 'px';
+    labelEls[i].style.top     = sy + 'px';
+    labelEls[i].style.display = (v.z < 1) ? 'block' : 'none';
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slider controls
+// ─────────────────────────────────────────────────────────────────────────────
+function bindSlider(id, valId, unit, key) {
+  const input = document.getElementById(id);
+  const valEl = document.getElementById(valId);
+  input.addEventListener('input', () => {
+    params[key] = parseFloat(input.value);
+    valEl.textContent = input.value + ' ' + unit;
+    rebuildScene();
+  });
+}
+bindSlider('towerX',    'towerXVal',    'mm', 'towerX');
+bindSlider('towerBotY', 'towerBotYVal', 'mm', 'towerBotY');
+bindSlider('horizLeg',  'horizLegVal',  'mm', 'horizLeg');
+bindSlider('camY',      'camYVal',      'mm', 'camY');
+
+rebuildScene();   // initial build — runs after labelEls is created
+
+// Mirror-fill preset: horizLeg/camY values that align the FOV top & bottom
+// edges with the top & bottom of the mirror face.
+const PRESET_MIRROR_FILL = { horizLeg: 116, camY: -14, towerX: -5, towerBotY: 139 };
+document.getElementById('presetMirrorFill').addEventListener('click', () => {
+  Object.assign(params, PRESET_MIRROR_FILL);
+  document.getElementById('horizLeg').value          = params.horizLeg;
+  document.getElementById('camY').value              = params.camY;
+  document.getElementById('towerX').value            = params.towerX;
+  document.getElementById('towerBotY').value         = params.towerBotY;
+  document.getElementById('horizLegVal').textContent = params.horizLeg  + '\u00a0mm';
+  document.getElementById('camYVal').textContent     = params.camY      + '\u00a0mm';
+  document.getElementById('towerXVal').textContent   = params.towerX    + '\u00a0mm';
+  document.getElementById('towerBotYVal').textContent= params.towerBotY + '\u00a0mm';
+  rebuildScene();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resize handler
+// ─────────────────────────────────────────────────────────────────────────────
+window.addEventListener('resize', () => {
+  cam.aspect = wrap.clientWidth / wrap.clientHeight;
+  cam.updateProjectionMatrix();
+  renderer.setSize(wrap.clientWidth, wrap.clientHeight);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Render loop
+// ─────────────────────────────────────────────────────────────────────────────
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  updateLabels();
+  renderer.render(scene, cam);
+}
+animate();
+</script>
+</body>
+</html>

--- a/Hardware/shopping-shortlist.md
+++ b/Hardware/shopping-shortlist.md
@@ -327,18 +327,16 @@ Safety defaults:
 - Clamp pulse width range to validated motor limits
 
 ### Display and Input
-- Display (selected): Waveshare 10.1EP-CAPLCD (1920x1200, capacitive touch)
-  - https://www.waveshare.com/10.1ep-caplcd.htm?sku=28881
-- Display (budget backup): Waveshare 10.1DP-CAPLCD (1280x800, capacitive touch)
-  - https://www.waveshare.com/10.1dp-caplcd.htm
-- Display (secondary fallback): Hosyond 7-inch 1024x600 capacitive HDMI display
-  - https://www.amazon.com/Hosyond-Display-1024%C3%97600-Capacitive-Raspberry/dp/B09XKC53NH/ref=sr_1_4?crid=9P679HBQGJSX&dib=eyJ2IjoiMSJ9.3PMO2XCtROfHo84ZcgeC4NXcAYlWQBqJlPNxu0IjI72ev0Yx0sZjc3puJjdbFN-Y9WcNBG1eMdLsjssz6HXncmLAGxXniSrKjVP9pMllnelVuDyCHFMqG9MohgZhxJnx5GcEvkAcpama_YfmDTfxKW3SqWbcaHuBd4meoj6Shirrt8gCBkqUtlPE5-6ANpAAYTdYQL_lwypSpbrUDl7qSJhksrWHgF0fvVWPGSE3lAesabVXtDQzUtmNP9CH-g_RIa9QUKJ2PwFLHsqjuZvUztim1UxJYSjpSHaXmR8SnT0.M3Ak8ize3u2sLKBbSiAvCLrixNZDvHG8Kc9FGGdRKb4&dib_tag=se&keywords=mini%2Bdisplay&qid=1776550537&s=electronics&sprefix=mini%2Bdisplay%2Celectronics%2C149&sr=1-4&th=1
-- Display integration decision notes:
-  - Option A (preferred for light control): touch glass and bezel external, display body internal, foam gasket around cutout to prevent light leaks.
-  - Option B (external bracket): display fully external with a single combined HDMI + USB-C panel feedthrough.
-  - I/O reservation for Option B: one HDMI path plus one USB path (Jetson USB-A to display USB-C cable), routed through the combined feedthrough.
-  - Cable check status: HDMI cable for the monitor is on hand.
-- Keyboard/Mouse: on-hand spare set confirmed.
+  - Display (selected): VIEWMEI 10.1" IPS Touchscreen (1280x800, HDMI, USB touch)
+    - https://www.amazon.com/dp/B0B7YQ5K6T
+  - Display Adapter: BENFEI DisplayPort (male) to HDMI (female)
+    - https://www.amazon.com/gp/product/B0C4XH8LZ1/ref=ewc_pr_img_2?smid=AANLIS3PF0Y1D&th=1
+  - Display integration decision notes:
+    - Option A (preferred for light control): touch glass and bezel external, display body internal, foam gasket around cutout to prevent light leaks.
+    - Option B (external bracket): display fully external with a single combined HDMI + USB panel feedthrough.
+    - I/O reservation for Option B: one HDMI path plus one USB path (Jetson USB-A to display USB cable), routed through the combined feedthrough.
+    - Cable check status: DisplayPort-to-HDMI adapter and HDMI cable for the monitor are on hand.
+  - Keyboard/Mouse: on-hand spare set confirmed.
 
 ### Lighting and Thermal
 - Lighting architecture (recommended): 12 V high-CRI COB LED strips in aluminum channels with diffuser, 3-zone layout (left, right, top-fill)

--- a/hardware_bom.md
+++ b/hardware_bom.md
@@ -1,0 +1,14 @@
+# Dice Tester Hardware BOM
+
+## Core Components
+
+| Item | Description | Link |
+|------|-------------|------|
+| Jetson Orin NX Dev Kit | Yahboom, 16GB RAM, 256GB SSD | (see project notes) |
+| Touchscreen Display | VIEWMEI 10.1" IPS, HDMI, USB Touch | https://www.amazon.com/dp/B0B7YQ5K6T |
+| Display Adapter | BENFEI DisplayPort (male) to HDMI (female) | https://www.amazon.com/gp/product/B0C4XH8LZ1/ref=ewc_pr_img_2?smid=AANLIS3PF0Y1D&th=1 |
+
+## Notes
+- Confirmed compatibility: DisplayPort output (Yahboom) to HDMI input (VIEWMEI) via BENFEI adapter.
+- USB touch interface for display.
+- See shopping-shortlist.md for additional candidate notes and requirements.


### PR DESCRIPTION
## Summary

Adds hardware documentation and an interactive 3D visualisation of the die tester optical path.

### `Hardware/optical_viz.html`
Interactive Three.js scene (runs in-browser, no server needed) showing the full optical path:
- **Camera body** positioned along the horizontal optical axis
- **45° first-surface mirror** with live Three.js `Reflector` (gold tint)
- **FOV pyramid + trapezoid footprint** on the mirror face (layer-separated so it doesn't appear in the mirror reflection)
- **Reflected FOV cone** from mirror up through the dice tower (teal)
- **Dice tower** cylinder with edge rings and a 3.75" capture ring / disc at the base
- **Clearance gap indicator** between mirror top and tower bottom
- **4 interactive sliders**: horizontal leg, camera Y offset, tower X offset, tower bottom Y
- **Mirror-fill preset button** (horizLeg=116, camY=−14, towerX=−5, towerBotY=139)
- **Explanatory sidebar** covering coordinate conventions, trapezoidal FOV footprint, all four tuning parameters, a preset values table, colour key, and controls guide
- Axis labels: X (width), Y (up/tower), Z (camera optical axis)

### Other files
- `Hardware/lens_wd_calc.py` — lens working-distance calculator
- `Hardware/optical-path-diagram.svg` — static optical path diagram
- `hardware_bom.md` — hardware bill of materials
- `Hardware/shopping-shortlist.md` — updated shopping shortlist